### PR TITLE
Fixed typo

### DIFF
--- a/lib/Utils/utils.dart
+++ b/lib/Utils/utils.dart
@@ -2,7 +2,7 @@ part of values;
 
 class Utils {
   static final double screenWidth = Get.width;
-  static final double screenHeight = Get.width;
+  static final double screenHeight = Get.height;
 }
 
 class SineCurve extends Curve {


### PR DESCRIPTION
Fixed typo, instead of using width, it will now use the height