### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.5
   responsive_builder: ^0.4.3
-  google_fonts: ^3.0.1
+  google_fonts: ^4.0.4
   get: ^4.6.5
   font_awesome_flutter: ^10.2.1
   flutter_shapes: ^0.3.0


### PR DESCRIPTION
Related to this issue there was a conflict with the old google font package (https://stackoverflow.com/questions/75347464/error-when-compiling-and-in-flutter-pub-upgrade-and-pub-outdated)
When cloning your repo and run 'flutter run' I got the following error: 
```
Could not build the precompiled application for the device.
Error (Xcode):
../../.pub-cache/hosted/pub.dev/google_fonts-3.0.1/lib/src/google_fonts_base.dart:14:1:
Error: 'AssetManifest' is imported from both
'package:flutter/src/services/asset_manifest.dart' and
'package:google_fonts/src/asset_manifest.dart'.



Error launching application on iPhone (3).

```

This get's resolved by updating the Google Font package. 